### PR TITLE
feat!: return only domain in result

### DIFF
--- a/internal/domain/hosts.go
+++ b/internal/domain/hosts.go
@@ -20,7 +20,8 @@ type HostsEntry struct {
 }
 
 func (e HostsEntry) String() string {
-	return e.IP.String() + " " + e.Domain
+	//return e.IP.String() + " " + e.Domain
+	return e.Domain
 }
 
 func (g *HostsGenerator) Gen(t time.Time) []HostsEntry {


### PR DESCRIPTION
This commit changes the output format of the return text to enable [wildcard domain blocking](https://0xerr0r.github.io/blocky/latest/configuration/#wildcard-support).